### PR TITLE
Patch zones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ reqwest = { version = "0.11.10", features = ["json"] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 serde_with = "1.12.0"
+thiserror = "1.0.40"
 
 [dev-dependencies]
 dotenvy = "0.15.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Display, Formatter, Write};
+use std::fmt::{Debug, Display, Formatter, Write};
 use reqwest::StatusCode;
 use serde::Deserialize;
 use thiserror::Error;
@@ -18,8 +18,11 @@ pub enum Error {
     UnexpectedStatusCode(StatusCode),
 
     // TODO: add serde error
-    #[error("other error: {}", 0)]
-    DeserializeError(#[from] Box<dyn std::error::Error>)
+    #[error("deserialization error: {0}")]
+    DeserializeError(#[from] serde_json::Error),
+
+    #[error("other error: {0}")]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync + 'static>)
 }
 
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,7 @@ pub enum Error {
     #[error("received unexpected status code: {}", 0)]
     UnexpectedStatusCode(StatusCode),
 
+    // TODO: add serde error
     #[error("other error: {}", 0)]
     DeserializeError(#[from] Box<dyn std::error::Error>)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,13 +11,11 @@ pub enum Error {
     #[error("powerdns returned error in response: {0:?}")]
     PowerDNS(#[from] PowerDNSResponseError),
 
-    #[error("error while performing request: {0}")]
+    #[error("error while performing request: {}", 0)]
     RequestError(#[from] reqwest::Error),
 
-    #[error("received unexpected status code: {0}")]
+    #[error("received unexpected status code: {}", 0)]
     UnexpectedStatusCode(StatusCode),
-
-
 
     #[error("deserialization error: {0}")]
     DeserializeError(#[from] serde_json::Error),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,42 @@
+use std::fmt::{Display, Formatter, Write};
+use reqwest::StatusCode;
 use serde::Deserialize;
+use thiserror::Error;
 
 /// Returned when the server encounters an error, either in client input or
 /// internally
-#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[derive(Error, Debug)]
 #[serde_with::skip_serializing_none]
-pub struct Error {
+pub enum Error {
+    #[error("powerdns returned error in response: {0:?}")]
+    PowerDNS(#[from] PowerDNSResponseError),
+
+    #[error("error while performing request: {}", 0)]
+    RequestError(#[from] reqwest::Error),
+
+    #[error("received unexpected status code: {}", 0)]
+    UnexpectedStatusCode(StatusCode),
+
+    #[error("other error: {}", 0)]
+    DeserializeError(#[from] Box<dyn std::error::Error>)
+}
+
+
+/// Represents PowerDNS response error
+#[derive(Default, PartialEq, Debug, Clone, Deserialize)]
+pub struct PowerDNSResponseError {
     /// A human readable error message
     pub error: String,
     /// Optional array of multiple errors encountered during processing
     pub errors: Option<Vec<String>>,
+}
+
+impl Display for PowerDNSResponseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&format!("error occurred: {}", self.error))
+    }
+}
+
+impl std::error::Error for PowerDNSResponseError {
+
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,8 @@ pub enum Error {
     #[error("received unexpected status code: {0}")]
     UnexpectedStatusCode(StatusCode),
 
+
+
     #[error("deserialization error: {0}")]
     DeserializeError(#[from] serde_json::Error),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,13 +11,12 @@ pub enum Error {
     #[error("powerdns returned error in response: {0:?}")]
     PowerDNS(#[from] PowerDNSResponseError),
 
-    #[error("error while performing request: {}", 0)]
+    #[error("error while performing request: {0}")]
     RequestError(#[from] reqwest::Error),
 
-    #[error("received unexpected status code: {}", 0)]
+    #[error("received unexpected status code: {0}")]
     UnexpectedStatusCode(StatusCode),
 
-    // TODO: add serde error
     #[error("deserialization error: {0}")]
     DeserializeError(#[from] serde_json::Error),
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 
 use crate::{Client, Error};
+use crate::error::PowerDNSResponseError;
 
 /// The server endpoint is the ‘basis’ for all other API operations. In the
 /// PowerDNS Authoritative Server, the server_id is always localhost. However,
@@ -60,7 +61,7 @@ impl<'a> ServerClient<'a> {
         if resp.status().is_success() {
             Ok(resp.json::<Vec<Server>>().await.unwrap())
         } else {
-            Err(resp.json::<Error>().await.unwrap())
+            Err(resp.json::<PowerDNSResponseError>().await?)?
         }
     }
 
@@ -95,7 +96,7 @@ impl<'a> ServerClient<'a> {
         if resp.status().is_success() {
             Ok(resp.json::<Server>().await.unwrap())
         } else {
-            Err(resp.json::<Error>().await.unwrap())
+            Err(resp.json::<PowerDNSResponseError>().await?)?
         }
     }
 }

--- a/src/zones.rs
+++ b/src/zones.rs
@@ -78,7 +78,7 @@ pub enum ZoneKind {
 
 /// PatchZones used to create zones with PATCH method.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct PatchZones {
+pub struct PatchZone {
     pub rrsets: Option<Vec<RRSet>>
 }
 
@@ -219,7 +219,7 @@ impl<'a> ZoneClient<'a> {
     }
 
     /// Patches zone, by assigning new rrsets to this zone.
-    pub async fn patch(&self, zone_id: &str, zone: Zone) -> Result<(), Error> {
+    pub async fn patch(&self, zone_id: &str, zone: PatchZone) -> Result<(), Error> {
         let response = self
             .api_client
             .http_client

--- a/src/zones.rs
+++ b/src/zones.rs
@@ -75,6 +75,13 @@ pub enum ZoneKind {
     Slave,
 }
 
+
+/// PatchZones used to create zones with PATCH method.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct PatchZones {
+    pub rrsets: Option<Vec<RRSet>>
+}
+
 // impl ZoneKind {
 //     fn as_str(&self) -> &'static str {
 //         match self {
@@ -212,7 +219,7 @@ impl<'a> ZoneClient<'a> {
     }
 
     /// Patches zone, by assigning new rrsets to this zone.
-    pub async fn patch(&self, zone_id: &str, rrset: RRSet) -> Result<(), Error> {
+    pub async fn patch(&self, zone_id: &str, zone: Zone) -> Result<(), Error> {
         let response = self
             .api_client
             .http_client
@@ -221,7 +228,7 @@ impl<'a> ZoneClient<'a> {
                         self.api_client.base_url,
                         self.api_client.server_name,
                 ))
-            .json(&rrset)
+            .json(&zone)
             .send()
             .await?;
 

--- a/src/zones.rs
+++ b/src/zones.rs
@@ -1,11 +1,16 @@
+use std::fmt::format;
+use std::os::macos::raw::stat;
 use addr::parse_domain_name;
-use serde::Deserialize;
+use reqwest::{Request, StatusCode};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 use crate::Client;
 use crate::Error;
+use crate::error::PowerDNSResponseError;
 
 /// A Zone object represents an authoritative DNS Zone.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde_with::skip_serializing_none]
 pub struct Zone {
     /// Opaque zone id (string), assigned by the server, should not be
@@ -63,7 +68,7 @@ pub struct Zone {
     pub slave_tsig_key_ids: Option<Vec<String>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub enum ZoneKind {
     Native,
     Master,
@@ -81,7 +86,7 @@ pub enum ZoneKind {
 // }
 
 /// This represents a Resource Record Set (all records with the same name and type).
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde_with::skip_serializing_none]
 pub struct RRSet {
     /// Name for record set (e.g. “www.powerdns.com.”)
@@ -113,7 +118,7 @@ pub struct RRSet {
 }
 
 /// The RREntry object represents a single record.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde_with::skip_serializing_none]
 pub struct Record {
     /// The content of this record
@@ -124,7 +129,7 @@ pub struct Record {
 }
 
 /// A comment about an RRSet.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde_with::skip_serializing_none]
 pub struct Comment {
     /// The actual comment
@@ -158,9 +163,9 @@ impl<'a> ZoneClient<'a> {
             .unwrap();
 
         if resp.status().is_success() {
-            Ok(resp.json::<Vec<Zone>>().await.unwrap())
+            Ok(resp.json::<Vec<Zone>>().await?)
         } else {
-            Err(resp.json::<Error>().await.unwrap())
+            Err(resp.json::<PowerDNSResponseError>().await?)?
         }
     }
 
@@ -179,9 +184,9 @@ impl<'a> ZoneClient<'a> {
             .unwrap();
 
         if resp.status().is_success() {
-            Ok(resp.json::<Zone>().await.unwrap())
+            Ok(resp.json::<Zone>().await?)
         } else {
-            Err(resp.json::<Error>().await.unwrap())
+            Err(resp.json::<PowerDNSResponseError>().await?)?
         }
     }
 
@@ -202,7 +207,37 @@ impl<'a> ZoneClient<'a> {
         if resp.status().is_success() {
             Ok(())
         } else {
-            Err(resp.json::<Error>().await.unwrap())
+            Err(resp.json::<PowerDNSResponseError>().await?)?
+        }
+    }
+
+    /// Patches zone, by assigning new rrsets to this zone.
+    pub async fn patch(&self, zone_id: &str, rrset: RRSet) -> Result<(), Error> {
+        let response = self
+            .api_client
+            .http_client
+            .patch(
+                format!("{}/api/v1/servers/{}/zones/{zone_id}",
+                        self.api_client.base_url,
+                        self.api_client.server_name,
+                ))
+            .json(&rrset)
+            .send()
+            .await?;
+
+        match response.status() {
+            // 204 No Content – Returns 204 No Content on success.
+            // 400 Bad Request – The supplied request was not valid Returns: Error object
+            // 404 Not Found – Requested item was not found Returns: Error object
+            // 422 Unprocessable Entity – The input to the operation was not valid Returns: Error object
+            // 500 Internal Server Error – Internal server error Returns: Error object
+
+            StatusCode::NO_CONTENT => Ok(()),
+            StatusCode::BAD_REQUEST | StatusCode::NOT_FOUND |
+            StatusCode::UNPROCESSABLE_ENTITY | StatusCode::INTERNAL_SERVER_ERROR => {
+                Err(Error::PowerDNS(response.json().await?))
+            },
+            status @ _ => Err(Error::UnexpectedStatusCode(status)),
         }
     }
 }

--- a/src/zones.rs
+++ b/src/zones.rs
@@ -1,9 +1,6 @@
-use std::fmt::format;
-use std::os::macos::raw::stat;
 use addr::parse_domain_name;
-use reqwest::{Request, StatusCode};
+use reqwest::{StatusCode};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 
 use crate::Client;
 use crate::Error;
@@ -79,7 +76,7 @@ pub enum ZoneKind {
 /// PatchZones used to create zones with PATCH method.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct PatchZone {
-    pub rrsets: Option<Vec<RRSet>>
+    pub rrsets: Vec<RRSet>
 }
 
 // impl ZoneKind {


### PR DESCRIPTION
Hi, thanks for the lib. 
I am using your lib and find out that API not fully implemented. I was needed patch method to create/replace zones, so I've added it in my PR.
Also, I rewrite an errors, so it is more easy to differentiate on error reason (PowerDNS returned error, connectivity issues, etc.). It need to add more errors though.

Can you please check and if it is useful to you, merge it, so we not maintain two forks at the same time. 
Thanks.